### PR TITLE
Fix for undeclared var

### DIFF
--- a/kyber768.js
+++ b/kyber768.js
@@ -645,7 +645,7 @@ function indcpaGenMatrix(seed, transposed, paramsK) {
             }
 
             // run rejection sampling on the output from above
-            outputlen = 3 * 168; // 504
+            var outputlen = 3 * 168; // 504
             var result = new Array(2);
             result = indcpaRejUniform(output.slice(0,504), outputlen, paramsN);
             a[i][j] = result[0]; // the result here is an NTT-representation


### PR DESCRIPTION
As per #1, when bundled with webpack:

```
Uncaught ReferenceError: outputlen is not defined at indcpaGenMatrix (webpack-internal:///./node_modules/crystals-kyber/kyber768.js:651)
```

Declaring the variable before use as per this PR fixes this.